### PR TITLE
[SECURITY] Prevent `rhostname` array overflow

### DIFF
--- a/CDFR_2019_MOT/Middlewares/Third_Party/LwIP/src/netif/ppp/eap.c
+++ b/CDFR_2019_MOT/Middlewares/Third_Party/LwIP/src/netif/ppp/eap.c
@@ -1417,7 +1417,7 @@ static void eap_request(ppp_pcb *pcb, u_char *inp, int id, int len) {
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			ppp_dbglog("EAP: trimming really long peer name down");
 			MEMCPY(rhostname, inp + vallen, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';
@@ -1845,7 +1845,7 @@ static void eap_response(ppp_pcb *pcb, u_char *inp, int id, int len) {
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			ppp_dbglog("EAP: trimming really long peer name down");
 			MEMCPY(rhostname, inp + vallen, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';


### PR DESCRIPTION
This is an automatically generated security fix for a vulnerability detected in your code which is a variant of [CVE-2020-8597](https://nvd.nist.gov/vuln/detail/CVE-2020-8597). 

You can read in more detail about this vulnerability in [CERT Advisory VU#782301](https://kb.cert.org/vuls/id/782301/).

The vulnerability occurs because, given that `vallen` was checked to be less than `len`, it can never be the case that `vallen >= len + sizeof(rhostname)`. Therefore, `rhostname` never gets trimmed and the `rhostname` array may overflow.

While this PR was generated for your project automatically, the supporting analysis was performed and verified by the [GitHub Security Lab](https://securitylab.github.com/). 

The original finding was reported by Ilja Van Sprundel from IOActive.

The proposed patch was developed by Paul Mackerras ([paulusmack](https://github.com/paulusmack)) from the Samba project in
[paulusmack/ppp@8d7970b#diff-b7f5f2404cf3f5c09b1f8ad9364bb340](https://github.com/paulusmack/ppp/commit/8d7970b8f3db727fe798b65f3377fe6787575426#diff-b7f5f2404cf3f5c09b1f8ad9364bb340).

The original vulnerability got assigned [CVE-2020-8597](https://nvd.nist.gov/vuln/detail/CVE-2020-8597) which has a CVSS v3.1 Base Score of [9.8/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2020-8597&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1&source=NIST).

## Source

The source code that generated and submitted this PR is based on [JLLeitschuh/bulk-security-pr-generator](https://github.com/JLLeitschuh/bulk-security-pr-generator).

## Opting-Out

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format. If you'd like to opt-out of any future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

'''
User-agent: GSL/bulk-security-pr-generator
Disallow: *
'''

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that we will be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.